### PR TITLE
Minor fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # (c) 2022 Retro Games Ltd
 #
 FROM debian:buster-slim
-MAINTAINER RetroGame Support <support@retrogames.biz>
+LABEL Maintainer="RetroGame Support <support@retrogames.biz>"
 
 RUN dpkg --add-architecture armhf
 RUN apt-get update

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
 # Docker Amiberry Redquark Build container
 
-## Create the build container and building Amiberry
+Requirements: 
+- Docker https://www.docker.com/
+- Git https://git-scm.com/
 
-1. Build the docker image from `Dockerfile`. This will install the necessary cross-compiler tools and source, and build Amiberry.
-2. Spin up a container from the image.
-3. The built `amiberry` binary will be found at `/build/redquark-amiberry-rb/amiberry`
-4. To rebuild Amiberry, run `/build/bootstrap.sh` in the container.
+## Step by step instructions
+
+1. Install Docker on your machine, from https://www.docker.com/
+2. Clone this repository: `git clone https://github.com/midwan/docker-amiberry-redquark`
+3. Move into the cloned repository: `cd docker-amiberry-redquark`
+4. Build the docker image from `Dockerfile`, giving it a name: `docker build --pull --rm -f "Dockerfile" -t amiberry-redquark:latest "."`
+This will: 
+  - Use a Debian Buster image
+  - Install the ARM cross-compiler tools and dependencies required
+  - Copy freetype-config inside the container 
+  - Execute `bootstrap.sh` which will download MaliFB, SDL2, SDL2-image, SDL2-ttf, and build Amiberry-Redquark.
+5. Spin up a container from the image: `docker run --rm -it amiberry-redquark:latest`
+6. The built `amiberry` binary will be found at `/build/redquark-amiberry-rb/amiberry`
+7. To rebuild Amiberry, you can re-run `/build/bootstrap.sh` in the container.
 
 ---
 **Applying any of the information contained in this repository to, or modifying THEA500 Mini in any way will render the

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements:
 ## Step by step instructions
 
 1. Install Docker on your machine, from https://www.docker.com/
-2. Clone this repository: `git clone https://github.com/midwan/docker-amiberry-redquark`
+2. Clone this repository: `git clone https://github.com/retro-games-ltd/docker-amiberry-redquark`
 3. Move into the cloned repository: `cd docker-amiberry-redquark`
 4. Build the docker image from `Dockerfile`, giving it a name: `docker build --pull --rm -f "Dockerfile" -t amiberry-redquark:latest "."`
 This will: 


### PR DESCRIPTION
Some minor fixes to ensure this works on non-Linux environments also:
- Added a .gitattributes file to ensure text files use LF characters only, in EOL (otherwise Windows would use CRLF and bash scripts would fail)
- Replaced deprecated MAINTAINER with LABEL in Dockerfile